### PR TITLE
Add colors for simple-thermostat buttons

### DIFF
--- a/themes/slate.yaml
+++ b/themes/slate.yaml
@@ -89,3 +89,5 @@ slate:
   material-background-color: "var(--paper-listbox-background-color)"
   material-secondary-background-color: '#222222'
   material-body-text-color: '#FFFFFF'
+  # simple-thermostat buttons
+  st-mode-background: 'var(--primary-background-color)'


### PR DESCRIPTION
Simple-Thermostat default background colors look like this:

<img width="467" alt="Screen Shot 2020-05-02 at 7 03 23 PM" src="https://user-images.githubusercontent.com/7717888/80895233-27e5fe00-8ca8-11ea-8182-370621ffe1f9.png">

After this change, the buttons will look like this:

<img width="469" alt="Screen Shot 2020-05-02 at 7 07 18 PM" src="https://user-images.githubusercontent.com/7717888/80895238-2fa5a280-8ca8-11ea-8984-6161df3e915c.png">
