### PR TITLE
Make background dark on markdown code renderings

### DIFF
--- a/themes/slate.yaml
+++ b/themes/slate.yaml
@@ -91,3 +91,5 @@ slate:
   material-body-text-color: '#FFFFFF'
   # simple-thermostat buttons
   st-mode-background: 'var(--primary-background-color)'
+  # fix white on white markdown code sections (eg. the addons infos)
+  markdown-code-background-color: 'var(--secondary-background-color)'


### PR DESCRIPTION
All markdown code sections on the supervisor addon pages are white on white like this.
![Unbenannt](https://user-images.githubusercontent.com/5469257/82831974-25974e00-9eba-11ea-8d30-7700e095d3ea.PNG)

The PR changes the background to the secondary background color so that is looks like:
![Unbenannt1](https://user-images.githubusercontent.com/5469257/82832015-419aef80-9eba-11ea-8fd8-6f4794488581.PNG)
