### PR TITLE
Add fix for card titles

### DIFF
--- a/themes/slate.yaml
+++ b/themes/slate.yaml
@@ -107,3 +107,6 @@ slate:
   input-label-ink-color: 'var(--secondary-text-color)'
   input-disabled-ink-color: 'var(--disabled-text-color)'
   input-dropdown-icon-color: 'var(--primary-text-color)'
+  
+  # fix for card title headers
+  ha-card-header-color: "var(--primary-text-color)"


### PR DESCRIPTION
Cards with a `Title:` as opposed to a `Name:` show up with text color equal to `rgb(33,33,33)`.  This PR fixes that.

```
type: vertical-stack
title: some card title
cards:
  - type: horizontal-stack
    cards:
      - type: entities
        entities:
```