### PR TITLE
Add clear-background-color for material web sliders

### DIFF
--- a/themes/slate.yaml
+++ b/themes/slate.yaml
@@ -15,6 +15,7 @@ slate:
   # Background colors
   primary-background-color: '#222222'
   secondary-background-color: '#222222'
+  clear-background-color: '#212121'
   divider-color: 'rgba(255, 255, 255, .12)'
   table-row-background-color: '#292929'
   table-row-alternative-background-color: '#292929'


### PR DESCRIPTION
The sliders used for dimmer/cover/etc controls recently changed to material web components in https://github.com/home-assistant/frontend/pull/18168

As noted in the [forums](https://community.home-assistant.io/t/text-color-for-light-slider/653489) this now renders the value as you're changing it in all white.  The default in the dark theme is [`#111111`](https://github.com/home-assistant/frontend/blob/20231208.2/src/resources/styles-data.ts#L8).  With slate I'm liking `#212121` which is just a touch less than the other background colors.

PS - thx for the theme, been using it for years!